### PR TITLE
Uniform API for DualView handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ void doSomething() {
     Kokkos::DualView<int *> dataDV("data", 10);
     bool isExecutedOnDevice = true;  // can be changed at will
 
-    // acquire data
+    // acquire up-to-date data
     auto dataV = dynk::getSyncedView(dataDV, isExecutedOnDevice);
 
     // modified parallel for

--- a/examples/example_1_layer.cpp
+++ b/examples/example_1_layer.cpp
@@ -8,8 +8,8 @@ template <typename T>
 TestArray<T> &TestArray<T>::operator+=(TestArray<T> const &other) {
   bool isExecutedOnDevice = true;
 
-  auto dataV = dynk::getViewAnonymous(mData, isExecutedOnDevice);
-  auto otherV = dynk::getViewAnonymous(other.mData, isExecutedOnDevice);
+  auto dataV = dynk::getView(mData, isExecutedOnDevice);
+  auto otherV = dynk::getView(other.mData, isExecutedOnDevice);
 
   dynk::parallel_for(
       isExecutedOnDevice, "perform += for test array", size(),

--- a/include/dynk/dual_view.hpp
+++ b/include/dynk/dual_view.hpp
@@ -28,24 +28,23 @@ auto getView(DualView &dualView) {
  *
  * The DualView memory spaces should match with the ones expected.
  *
- * @tparam T Type of the DualView.
- * @tparam P Parameters of the DualView.
  * @tparam DeviceMemorySpace Device memory space, defaults to the default
  * execution space's default memory space.
  * @tparam HostMemorySpace Host memory space, defaults to the default host
  * execution space's default memory space.
+ * @tparam T Type of the DualView.
+ * @tparam P Parameters of the DualView.
  * @param dualView DualView to take a view from.
  * @param isExecutedOnDevice If `true`, returns the device view, otherwise,
  * returns the host view.
  * @return View in the requested memory space.
  */
 template <
-    typename T, typename... P,
     typename DeviceMemorySpace = Kokkos::DefaultExecutionSpace::memory_space,
-    typename HostMemorySpace = Kokkos::DefaultHostExecutionSpace::memory_space>
+    typename HostMemorySpace = Kokkos::DefaultHostExecutionSpace::memory_space,
+    typename T, typename... P>
 Kokkos::View<T, Kokkos::AnonymousSpace, P...>
-getViewAnonymous(Kokkos::DualView<T, P...> &dualView,
-                 bool const isExecutedOnDevice) {
+getView(Kokkos::DualView<T, P...> &dualView, bool const isExecutedOnDevice) {
   if (isExecutedOnDevice) {
     return getView<DeviceMemorySpace>(dualView);
   } else {
@@ -58,24 +57,24 @@ getViewAnonymous(Kokkos::DualView<T, P...> &dualView,
  *
  * The DualView memory spaces should match with the ones expected.
  *
- * @tparam T Type of the DualView.
- * @tparam P Parameters of the DualView.
  * @tparam DeviceMemorySpace Device memory space, defaults to the default
  * execution space's default memory space.
  * @tparam HostMemorySpace Host memory space, defaults to the default host
  * execution space's default memory space.
+ * @tparam T Type of the DualView.
+ * @tparam P Parameters of the DualView.
  * @param dualView DualView to take a view from.
  * @param isExecutedOnDevice If `true`, returns the device view, otherwise,
  * returns the host view.
  * @return View in the requested memory space.
  */
 template <
-    typename T, typename... P,
     typename DeviceMemorySpace = Kokkos::DefaultExecutionSpace::memory_space,
-    typename HostMemorySpace = Kokkos::DefaultHostExecutionSpace::memory_space>
+    typename HostMemorySpace = Kokkos::DefaultHostExecutionSpace::memory_space,
+    typename T, typename... P>
 Kokkos::View<T, Kokkos::AnonymousSpace, P...>
-getViewAnonymous(Kokkos::DualView<T, P...> const &dualView,
-                 bool const isExecutedOnDevice) {
+getView(Kokkos::DualView<T, P...> const &dualView,
+        bool const isExecutedOnDevice) {
   if (isExecutedOnDevice) {
     return getView<DeviceMemorySpace>(dualView);
   } else {
@@ -100,6 +99,35 @@ template <typename MemorySpace, typename DualView>
 auto getSyncedView(DualView &dualView) {
   dualView.template sync<MemorySpace>();
   return getView<MemorySpace>(dualView);
+}
+
+/**
+ * Get a View of a DualView dynamically and sychronize it if needed.
+ *
+ * The DualView memory spaces should match with the ones expected.
+ *
+ * @tparam DeviceMemorySpace Device memory space, defaults to the default
+ * execution space's default memory space.
+ * @tparam HostMemorySpace Host memory space, defaults to the default host
+ * execution space's default memory space.
+ * @tparam DualView Type of the DualView.
+ * @param dualView DualView to take a view from.
+ * @param isExecutedOnDevice If `true`, returns the device view, otherwise,
+ * returns the host view.
+ * @return View in the requested memory space, synchronized.
+ */
+template <
+    typename DeviceMemorySpace = Kokkos::DefaultExecutionSpace::memory_space,
+    typename HostMemorySpace = Kokkos::DefaultHostExecutionSpace::memory_space,
+    typename DualView>
+auto getSyncedView(DualView &dualView, bool const isExecutedOnDevice) {
+  if (isExecutedOnDevice) {
+    dualView.template sync<DeviceMemorySpace>();
+  } else {
+    dualView.template sync<HostMemorySpace>();
+  }
+  return getView<DeviceMemorySpace, HostMemorySpace>(dualView,
+                                                     isExecutedOnDevice);
 }
 
 /**
@@ -131,9 +159,9 @@ void setModified(DualView &dualView) {
  * mark host view as modified.
  */
 template <
-    typename DualView,
     typename DeviceMemorySpace = Kokkos::DefaultExecutionSpace::memory_space,
-    typename HostMemorySpace = Kokkos::DefaultHostExecutionSpace::memory_space>
+    typename HostMemorySpace = Kokkos::DefaultHostExecutionSpace::memory_space,
+    typename DualView>
 void setModified(DualView &dualView, bool const isExecutedOnDevice) {
   if (isExecutedOnDevice) {
     setModified<DeviceMemorySpace>(dualView);

--- a/tests/test_layer.cpp
+++ b/tests/test_layer.cpp
@@ -4,11 +4,42 @@
 
 #include "dynk/layer.hpp"
 
+TEST(test_get_view, test_default) {
+  using DeviceSpace = Kokkos::DefaultExecutionSpace::memory_space;
+  using DualView = Kokkos::DualView<int *>;
+  DualView dataDV("data", 10);
+
+  auto dataD = dynk::getView(dataDV, true);
+  EXPECT_EQ(dataD.data(), dataDV.template view<DeviceSpace>().data());
+
+  auto dataH = dynk::getView(dataDV, false);
+  EXPECT_EQ(dataH.data(), dataDV.template view<Kokkos::HostSpace>().data());
+}
+
+TEST(test_get_view, test_non_default) {
+  using DeviceSpace = Kokkos::DefaultExecutionSpace::memory_space;
+  using DualView = Kokkos::DualView<int *>;
+  DualView dataDV("data", 10);
+
+  auto dataH1 = dynk::getView<Kokkos::HostSpace>(dataDV, true);
+  EXPECT_EQ(dataH1.data(), dataDV.template view<Kokkos::HostSpace>().data());
+
+  auto dataH2 =
+      dynk::getView<Kokkos::HostSpace, Kokkos::HostSpace>(dataDV, false);
+  EXPECT_EQ(dataH2.data(), dataDV.template view<Kokkos::HostSpace>().data());
+
+  auto dataD1 = dynk::getView<DeviceSpace>(dataDV, true);
+  EXPECT_EQ(dataD1.data(), dataDV.template view<DeviceSpace>().data());
+
+  auto dataD2 = dynk::getView<DeviceSpace, DeviceSpace>(dataDV, false);
+  EXPECT_EQ(dataD2.data(), dataDV.template view<DeviceSpace>().data());
+}
+
 void test_parallel_for_range(bool const isExecutedOnDevice) {
   using DualView = Kokkos::DualView<int *>;
   DualView dataDV("data", 10);
 
-  auto dataV = dynk::getViewAnonymous(dataDV, isExecutedOnDevice);
+  auto dataV = dynk::getView(dataDV, isExecutedOnDevice);
   dynk::parallel_for(
       isExecutedOnDevice, "label", dynk::RangePolicy(0, 10),
       KOKKOS_LAMBDA(int const i) { dataV(i) = i; });
@@ -23,11 +54,35 @@ TEST(test_parallel_for, test_range) {
   test_parallel_for_range(false);
 }
 
+void test_parallel_for_range_unsync(bool const isExecutedOnDevice) {
+  using DualView = Kokkos::DualView<int *>;
+  DualView dataDV("data", 10);
+
+  // pre-alter data
+  auto dataAlteration = dataDV.template view<Kokkos::HostSpace>();
+  Kokkos::deep_copy(dataAlteration, 10);
+  dataDV.template modify<Kokkos::HostSpace>();
+
+  auto dataV = dynk::getSyncedView(dataDV, isExecutedOnDevice);
+  dynk::parallel_for(
+      isExecutedOnDevice, "label", dynk::RangePolicy(0, 10),
+      KOKKOS_LAMBDA(int const i) { dataV(i) += i; });
+  dynk::setModified(dataDV, isExecutedOnDevice);
+
+  dataDV.template sync<typename DualView::host_mirror_space>();
+  EXPECT_EQ(dataDV.h_view(5), 15);
+}
+
+TEST(test_parallel_for, test_range_unsync) {
+  test_parallel_for_range_unsync(true);
+  test_parallel_for_range_unsync(false);
+}
+
 void test_parallel_for_range_simple(bool const isExecutedOnDevice) {
   using DualView = Kokkos::DualView<int *>;
   DualView dataDV("data", 10);
 
-  auto dataV = dynk::getViewAnonymous(dataDV, isExecutedOnDevice);
+  auto dataV = dynk::getView(dataDV, isExecutedOnDevice);
   dynk::parallel_for(
       isExecutedOnDevice, "label", 10,
       KOKKOS_LAMBDA(int const i) { dataV(i) = i; });
@@ -46,7 +101,7 @@ void test_parallel_for_mdrange(bool const isExecutedOnDevice) {
   using DualView = Kokkos::DualView<int **>;
   DualView dataDV("data", 10, 10);
 
-  auto dataV = dynk::getViewAnonymous(dataDV, isExecutedOnDevice);
+  auto dataV = dynk::getView(dataDV, isExecutedOnDevice);
   dynk::parallel_for(
       isExecutedOnDevice, "label",
       dynk::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {10, 10}),
@@ -66,7 +121,7 @@ void test_parallel_for_mdrange_tile(bool const isExecutedOnDevice) {
   using DualView = Kokkos::DualView<int **>;
   DualView dataDV("data", 10, 10);
 
-  auto dataV = dynk::getViewAnonymous(dataDV, isExecutedOnDevice);
+  auto dataV = dynk::getView(dataDV, isExecutedOnDevice);
   dynk::parallel_for(
       isExecutedOnDevice, "label",
       dynk::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {10, 10}, {2, 2}),
@@ -86,7 +141,7 @@ void test_parallel_reduce_range(bool const isExecutedOnDevice) {
   using DualView = Kokkos::DualView<int *>;
   DualView dataDV("data", 10);
 
-  auto dataV = dynk::getViewAnonymous(dataDV, isExecutedOnDevice);
+  auto dataV = dynk::getView(dataDV, isExecutedOnDevice);
   int value = 0;
   dynk::parallel_reduce(
       isExecutedOnDevice, "label", dynk::RangePolicy(0, 10),


### PR DESCRIPTION
This PR improves the project by providing a consistent DualView handling API:

- Renamed `dynk::getViewAnonymous` into `dynk::getView` (the signature is different enough to distinguish them);
- Created `dynk::getSyncedView` with the Boolean argument version;
- Fixed a bug of template arguments order;
- Added tests for `dynk::getView` template arguments, and for `dynk::getSyncedView` with the Boolean argument.